### PR TITLE
correct data shape bug

### DIFF
--- a/apres/__init__.py
+++ b/apres/__init__.py
@@ -209,10 +209,10 @@ class ApRESBurst(object):
                 elif flatten.lower() == 'unity':
                     if m > 1:
                         self.data_dim_keys.append(key)
-                        data_shape.append(m)
+                        data_shape.insert(1, m)
                 elif flatten.lower() == 'never':
                     self.data_dim_keys.append(key)
-                    data_shape.append(m)
+                    data_shape.insert(1, m)
             except KeyError:
                 pass
             except ValueError:

--- a/tests/test_apres.py
+++ b/tests/test_apres.py
@@ -171,7 +171,7 @@ class TestApRESBurst(unittest.TestCase):
         f.store_header()
         f.define_data_shape()
         self.assertEqual(['NSubBursts','N_ADC_SAMPLES','nAttenuators'], f.data_dim_keys)
-        self.assertEqual((100,40001,2), f.data_shape)
+        self.assertEqual((100,2,40001), f.data_shape)
 
     def test_define_data_shape_flatten_unity_eq_1(self):
         f = ApRESBurst()
@@ -187,7 +187,7 @@ class TestApRESBurst(unittest.TestCase):
         f.store_header()
         f.define_data_shape(flatten='unity')
         self.assertEqual(['NSubBursts','N_ADC_SAMPLES','nAttenuators'], f.data_dim_keys)
-        self.assertEqual((100,40001,2), f.data_shape)
+        self.assertEqual((100,2,40001), f.data_shape)
 
     def test_define_data_shape_flatten_always_eq_1(self):
         f = ApRESBurst()
@@ -211,7 +211,7 @@ class TestApRESBurst(unittest.TestCase):
         f.store_header()
         f.define_data_shape(flatten='never')
         self.assertEqual(['NSubBursts','N_ADC_SAMPLES','nAttenuators'], f.data_dim_keys)
-        self.assertEqual((100,40001,1), f.data_shape)
+        self.assertEqual((100,1,40001), f.data_shape)
 
     def test_define_data_shape_flatten_never_gt_1(self):
         f = ApRESBurst()
@@ -219,7 +219,7 @@ class TestApRESBurst(unittest.TestCase):
         f.store_header()
         f.define_data_shape(flatten='never')
         self.assertEqual(['NSubBursts','N_ADC_SAMPLES','nAttenuators'], f.data_dim_keys)
-        self.assertEqual((100,40001,2), f.data_shape)
+        self.assertEqual((100,2,40001), f.data_shape)
 
     def test_define_data_shape_flatten_invalid_value(self):
         f = ApRESBurst()


### PR DESCRIPTION
This is an updated PR to address #3 : a bug in reshaping the data when more than one attenuator setting is used. 

It just changes two lines in __init__.py and four lines in test_apres.py
